### PR TITLE
Add Vercel-ready web app for viewing prediction results

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ python main_ensemble.py
 ### 查看結果
 訓練完成後，可以在`model_results/@summary.html`中查看詳細的模型比較和分析結果。
 
+### 啟動預測結果展示 Web App
+本專案提供可部署至 Vercel 的簡易網頁介面。
+在本地啟動後端 API：
+```bash
+uvicorn api.prediction_api:app --reload
+```
+然後在瀏覽器中開啟 `index.html` 查看預測結果。
+
+若要部署至 [Vercel](https://vercel.com/)，安裝 Vercel CLI 並執行 `vercel` 即可。儲存庫已包含 `vercel.json` 設定。
+
 ## 可視化說明
 
 1. **模型性能比較圖**

--- a/api/prediction_api.py
+++ b/api/prediction_api.py
@@ -1,0 +1,49 @@
+import os
+import glob
+from typing import List, Dict
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+MODEL_RESULTS_DIR = "model_results"
+
+app = FastAPI(title="House Price Prediction API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"]
+)
+
+
+def get_submission_files(directory: str) -> List[str]:
+    pattern = os.path.join(directory, "*_submission.csv")
+    return sorted(glob.glob(pattern))
+
+
+@app.get("/api/files")
+def list_files() -> Dict[str, List[str]]:
+    files = [os.path.basename(f) for f in get_submission_files(MODEL_RESULTS_DIR)]
+    return {"files": files}
+
+
+@app.get("/api/predictions")
+def get_predictions(file: str) -> Dict[str, List[Dict[str, float]]]:
+    file_path = os.path.join(MODEL_RESULTS_DIR, file)
+    if not os.path.isfile(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    df = pd.read_csv(file_path)
+    preview = df.head().to_dict(orient="records")
+
+    if "SalePrice" in df.columns:
+        hist = df["SalePrice"].value_counts(bins=50, sort=False)
+        histogram = {
+            "bins": [f"{int(bin.left)}-{int(bin.right)}" for bin in hist.index],
+            "counts": hist.values.tolist(),
+        }
+    else:
+        histogram = {}
+
+    return {"preview": preview, "histogram": histogram}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>House Price Predictions</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>House Price Prediction Results</h1>
+  <div>
+    <label for="fileSelect">Select a submission file:</label>
+    <select id="fileSelect"></select>
+  </div>
+  <div id="preview"></div>
+  <canvas id="chart"></canvas>
+  <script>
+    async function loadFiles() {
+      const res = await fetch('/api/files');
+      const data = await res.json();
+      const select = document.getElementById('fileSelect');
+      select.innerHTML = '';
+      data.files.forEach(f => {
+        const opt = document.createElement('option');
+        opt.value = f;
+        opt.textContent = f;
+        select.appendChild(opt);
+      });
+      if (data.files.length > 0) {
+        loadData(select.value);
+        select.onchange = () => loadData(select.value);
+      } else {
+        document.getElementById('preview').textContent = 'No submission files found.';
+      }
+    }
+
+    let chart;
+    async function loadData(file) {
+      const res = await fetch(`/api/predictions?file=${file}`);
+      const data = await res.json();
+      const previewDiv = document.getElementById('preview');
+      previewDiv.innerHTML = '<h2>Preview</h2>';
+      const table = document.createElement('table');
+      if (data.preview.length > 0) {
+        const headers = Object.keys(data.preview[0]);
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        headers.forEach(h => {
+          const th = document.createElement('th');
+          th.textContent = h;
+          headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        data.preview.forEach(row => {
+          const tr = document.createElement('tr');
+          headers.forEach(h => {
+            const td = document.createElement('td');
+            td.textContent = row[h];
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+      }
+      previewDiv.appendChild(table);
+
+      if (data.histogram && data.histogram.bins) {
+        const ctx = document.getElementById('chart').getContext('2d');
+        if (chart) chart.destroy();
+        chart = new Chart(ctx, {
+          type: 'bar',
+          data: {
+            labels: data.histogram.bins,
+            datasets: [{ label: 'SalePrice Distribution', data: data.histogram.counts }]
+          }
+        });
+      }
+    }
+
+    loadFiles();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ scikit-optimize>=0.9.0
 category_encoders>=2.4.0
 tensorflow>=2.8.0
 keras>=2.8.0 
+fastapi>=0.95.0
+uvicorn>=0.20.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "builds": [
+    {"src": "api/*.py", "use": "@vercel/python"},
+    {"src": "index.html", "use": "@vercel/static"}
+  ]
+}


### PR DESCRIPTION
## Summary
- replace Streamlit UI with FastAPI API and static HTML page that lists submission files and charts sale price distribution
- add Vercel configuration and document how to run/deploy the web app
- update requirements to include FastAPI and uvicorn

## Testing
- `python -m py_compile api/prediction_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689635ab31f88328abb375f2ac036467